### PR TITLE
Callbacks through emit

### DIFF
--- a/play/index.js
+++ b/play/index.js
@@ -252,3 +252,34 @@ play('Carousel3d', module)
             }
         }
     })
+
+    .add("callbacks through emit", {
+        template: `<carousel-3d
+                      @afterSlideChanged="onAfterSlideChanged"
+                      @lastSlide="onLastSlide"
+                      @slideChange="onSlideChange">
+            <slide v-for="(slide, i) in slides" :index="i">
+                <img :src="slide.src">
+            </slide>
+        </carousel-3d>`,
+        components: {
+            Carousel3d,
+            Slide
+        },
+        data() {
+            return {
+                slides: slides
+            }
+        },
+        methods: {
+            onAfterSlideChanged(index){
+                console.log('@afterSlideChanged Callback Triggered', 'Slide Index ' + index)
+            },
+            onSlideChange(index){
+                console.log('@slideChange Callback Triggered', 'Slide Index ' + index)
+            },
+            onLastSlide(index){
+                console.log('@lastSlide Callback Triggered', 'Slide Index ' + index)
+            }
+        }
+    })

--- a/src/Carousel3d.vue
+++ b/src/Carousel3d.vue
@@ -207,8 +207,15 @@
                 this.lock = true
 
                 if (this.isLastSlide) {
+                    if (this.onLastSlide !== noop) {
+                        console.warn('onLastSlide deprecated, please use @lastSlide')
+                    }
                     this.onLastSlide(this.currentIndex)
+
+                    this.$emit('lastSlide', this.currentIndex)
                 }
+
+                this.$emit('slideChange', this.currentIndex)
 
                 setTimeout(() => this.animationEnd(), this.animationSpeed)
             },
@@ -240,7 +247,13 @@
              */
             animationEnd () {
                 this.lock = false
+
+                if (this.onSlideChange !== noop) {
+                    console.warn('onSlideChange deprecated, please use @afterSlideChanged')
+                }
                 this.onSlideChange(this.currentIndex)
+
+                this.$emit('afterSlideChanged', this.currentIndex)
             },
             /**
              * Trigger actions when mouse is released


### PR DESCRIPTION
I think the default way to handle callbacks in Vue are through event emission. Furthermore I needed a way to respond to a slide change when it starts, not when it ends. So I made these few changes.

I added deprecation warnings instead of removing the old methods so as not to break anything. They are logged when `callback !== noop` Transitioning for existing users should be simple. ex:

```vue
<!-- Now -->
<carousel-3d :onSlideChange="onSlideChange"
             :onLastSlide="onLastSlide">

<!-- Becomes -->
<carousel-3d @afterSlideChanged="onAfterSlideChanged"
             @lastSlide="onLastSlide"
             @slideChange="onSlideChange"> <!-- new event -->
```

As you can see there are some ambiguity issues because of the naming chosen in the past. `onSlideChange` is triggered before/at the moment your slider starts changing whilst the previous `onSlideChanged` is triggered after the animation occured. Therefore I renamed it to `onAfterSlideChanged` so there is a clearer distinction.

Let me know if this needs some more work.