### PR TITLE
Remove the console logging

### DIFF
--- a/src/Carousel3d.vue
+++ b/src/Carousel3d.vue
@@ -186,7 +186,6 @@
             },
             rightIndices () {
                 let n = (this.visible - 1) / 2
-                console.log(this.bias)
                 n = (this.bias.toLowerCase() === 'right' ? Math.ceil(n) : Math.floor(n))
                 const indices = []
 


### PR DESCRIPTION
Twice when creating the component and then every time I swipe my carousel, it logs `left` on my console.