### PR TITLE
Fixed carousel resetting current slide to startIndex after window resize

### DIFF
--- a/src/Carousel3d.vue
+++ b/src/Carousel3d.vue
@@ -190,7 +190,7 @@
             },
             rightIndices () {
                 let n = (this.visible - 1) / 2
-                
+
                 n = (this.bias.toLowerCase() === 'right' ? Math.ceil(n) : Math.floor(n))
                 const indices = []
 
@@ -405,9 +405,12 @@
             /**
              * Re-compute the number of slides and current slide
              */
-            computeData () {
+            computeData (firstRun) {
                 this.total = this.getSlideCount()
-                this.currentIndex = parseInt(this.startIndex) > this.total - 1 ? this.total - 1 : parseInt(this.startIndex)
+                if (firstRun || this.currentIndex >= this.total) {
+                    this.currentIndex = parseInt(this.startIndex) > this.total - 1 ? this.total - 1 : parseInt(this.startIndex)
+                }
+
                 this.viewport = this.$el.clientWidth
             },
             setSize () {
@@ -417,7 +420,7 @@
         },
 
         mounted () {
-            this.computeData()
+            this.computeData(true)
             this.attachMutationObserver()
 
             if (!this.$isServer) {

--- a/tests/client/components/Carousel3d.spec.js
+++ b/tests/client/components/Carousel3d.spec.js
@@ -202,5 +202,35 @@ describe('Carousel3d', () => {
 		return utils.expectToMatchSnapshot(vm);
 	});
 
+    it('should not change current slide index if computeData called and total number of slides have not change and in of bounds ', () => {
+        const vm = new Vue({
+            el: document.createElement('div'),
+            render: (h) => h(Carousel3d, { props: { startIndex: 0, loop: false } }, [h(Slide), h(Slide)]),
+        });
+        const carouselInstance = vm.$children[0];
+        return carouselInstance.$nextTick().then(() => {
+            carouselInstance.goNext();
+            carouselInstance.computeData();
+            expect(carouselInstance.$data.currentIndex).toBe(1);
+    
+            return utils.expectToMatchSnapshot(vm);
+        });
+    });
+
+    it('should change current slide index if computeData called and current slide index falls out of bounds ', () => {
+        const vm = new Vue({
+            el: document.createElement('div'),
+            render: (h) => h(Carousel3d, { props: { startIndex: 0, loop: false } }, [h(Slide), h(Slide), h(Slide)]),
+        });
+        const carouselInstance = vm.$children[0];
+        return carouselInstance.$nextTick().then(() => {
+            carouselInstance.goSlide(2);
+            carouselInstance.$slots.default.pop();
+            carouselInstance.computeData();
+            expect(carouselInstance.$data.currentIndex).toBe(0);
+    
+            return utils.expectToMatchSnapshot(vm);
+        });
+    });
 
 })

--- a/tests/client/components/__snapshots__/Carousel3d.spec.js.snap
+++ b/tests/client/components/__snapshots__/Carousel3d.spec.js.snap
@@ -38,6 +38,15 @@ exports[`Carousel3d should be able to go on prev slide if start slide index is 0
 "
 `;
 
+exports[`Carousel3d should change current slide index if computeData called and current slide index falls out of bounds  1`] = `
+".carousel-3d-slider(style=\'width: 0px; height: 0px;\')
+  .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
+  .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
+  .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
+// 
+"
+`;
+
 exports[`Carousel3d should decrease current index number by 1 when goPrev is called 1`] = `
 ".carousel-3d-slider(style=\'width: 0px; height: 0px;\')
   .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
@@ -63,6 +72,14 @@ exports[`Carousel3d should mount successfully 1`] = `
 `;
 
 exports[`Carousel3d should not be able to go on next slide if start slide index is 1, loop is disabled and there are 2 slides  1`] = `
+".carousel-3d-slider(style=\'width: 0px; height: 0px;\')
+  .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
+  .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
+// 
+"
+`;
+
+exports[`Carousel3d should not change current slide index if computeData called and total number of slides have not change and in of bounds  1`] = `
 ".carousel-3d-slider(style=\'width: 0px; height: 0px;\')
   .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')
   .carousel-3d-slide(style=\'border-width: 1px; width: 0px; height: 0px;\')


### PR DESCRIPTION
This was triggered indirectly by setSize triggering a MutationObserver, which triggered  computeData. That computeData call would always clobber our currentIndex property. I also added a couple of tests for good measure.