### PR TITLE
Lower z-index to better work with the slider

### DIFF
--- a/src/Controls.vue
+++ b/src/Controls.vue
@@ -62,13 +62,13 @@
         margin-top: -30px;
         left: 0;
         width: 100%;
-        z-index: 9099;
+        z-index: 1000;
     }
 
     .next, .prev {
         width: 60px;
         position: absolute;
-        z-index: 9999;
+        z-index: 1010;
         font-size: 60px;
         height: 60px;
         line-height: 60px;


### PR DESCRIPTION
I am trying to overlay something over the Carousel but due to the .next and .prev z-index of 9999 I am not able to.