### PR TITLE
Fix slide direction

### DIFF
--- a/src/Slide.vue
+++ b/src/Slide.vue
@@ -33,8 +33,8 @@
                 let styles = {}
 
                 if (!this.isCurrent) {
-                    const rIndex = this.leftIndex
-                    const lIndex = this.rightIndex
+                    const lIndex = this.leftIndex
+                    const rIndex = this.rightIndex
                     if (rIndex >= 0 || lIndex >= 0) {
                         styles = rIndex >= 0 ? this.calculatePosition(rIndex, true, this.zIndex) : this.calculatePosition(lIndex, false, this.zIndex)
                         styles.opacity = 1


### PR DESCRIPTION
as https://github.com/Wlada/vue-carousel-3d/issues/113, swiping movement(direction) reversed after `v0.1.21` .

See the following GIFs to understand the problem.

**Current behavior:**
When swiping from right to left, the slide moves left to right.

![Mar-22-2019_15-36-47](https://user-images.githubusercontent.com/32442796/54805562-a8bb8380-4cba-11e9-8f13-5f29a603eda1.gif)

**This PR:**
When swiping from right to left, the slide moves right to left.
This is the same behavior as before v0.1.21.

![Mar-22-2019_15-41-51](https://user-images.githubusercontent.com/32442796/54805571-afe29180-4cba-11e9-8799-871423b9579e.gif)

## Warning for developers who use v0.1.21 or later.

This is a **breaking change** for you.
(However, I just reverted the behavior to the same as before `v0.1.21`.)