### PR TITLE
fix !autoplayHoverPause && autoplay

### DIFF
--- a/src/carousel-3d/mixins/autoplay.js
+++ b/src/carousel-3d/mixins/autoplay.js
@@ -53,9 +53,9 @@ const autoplay = {
         if (!process.server && this.autoplayHoverPause) {
             this.$el.addEventListener('mouseenter', this.pauseAutoplay)
             this.$el.addEventListener('mouseleave', this.startAutoplay)
-
-            this.startAutoplay()
         }
+        
+        this.startAutoplay()
     }
 }
 


### PR DESCRIPTION
When autoplay enable and autoplayHoverPause false, the carousel doesn't start the autoplay